### PR TITLE
Foundation 2/3: App shell, design tokens, globals.css (align with spec)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,7 +19,7 @@
   --on-deep: #F4EFE6;
   --on-deep-mute: rgba(244, 239, 230, 0.60);
 
-  --radius-pill: 999px;
+  --pill: 999px;
   --radius-lg: 14px;
   --radius-md: 12px;
   --radius-sm: 8px;
@@ -27,11 +27,22 @@
 
   --motion-fast: 160ms;
   --motion-base: 250ms;
+
+  --font-sans: var(--font-geist, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif);
+  --font-serif: var(--font-newsreader, 'Iowan Old Style', Georgia, serif);
+  --font-mono: var(--font-plex, 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 @layer base {
   body {
-    @apply font-sans bg-paper text-ink;
+    background: var(--paper);
+    color: var(--ink);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
   }
@@ -44,7 +55,7 @@
   }
 
   :focus-visible {
-    outline: 2px solid var(--teal);
+    outline: 2px solid var(--ink);
     outline-offset: 2px;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,30 +1,9 @@
 import type { Metadata } from 'next';
-import { Geist, Newsreader, IBM_Plex_Mono } from 'next/font/google';
 import './globals.css';
-
-const geist = Geist({
-  subsets: ['latin'],
-  variable: '--font-geist',
-  display: 'swap',
-});
-
-const newsreader = Newsreader({
-  subsets: ['latin'],
-  variable: '--font-newsreader',
-  display: 'swap',
-  style: ['normal', 'italic'],
-});
-
-const plex = IBM_Plex_Mono({
-  subsets: ['latin'],
-  weight: ['400', '500'],
-  variable: '--font-plex',
-  display: 'swap',
-});
 
 export const metadata: Metadata = {
   title: 'Working with Me',
-  description: 'Working with Me',
+  description: 'A space to post Assignments, mark Commitments, and broadcast Connections.',
 };
 
 export default function RootLayout({
@@ -33,8 +12,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={`${geist.variable} ${newsreader.variable} ${plex.variable}`}>
-      <body className="font-sans bg-paper text-ink">{children}</body>
+    <html lang="en">
+      <body>{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,3 @@
 export default function Page() {
-  return (
-    <main className="p-8">
-      <h1>Working with Me</h1>
-    </main>
-  );
+  return <main className="container mx-auto p-14">Working with Me</main>;
 }


### PR DESCRIPTION
Closes #27

## Summary
Commit 6d93c0b landed an initial Next 15 scaffold under app/, but the three files diverge from the Foundation 2/3 spec in ways that break stated invariants and anti-requirements: (1) app/layout.tsx wires next/font (Geist, Newsreader, IBM_Plex_Mono) — explicitly forbidden in this child; (2) layout metadata.description is the placeholder 'Working with Me' instead of the required 'A space to post Assignments, mark Commitments, and broadcast Connections.'; (3) app/globals.css declares --radius-pill (999px) instead of the spec name --pill, omits --font-sans/--font-serif/--font-mono fallback declarations, has no global box-sizing reset, and the :focus-visible outline uses var(--teal) instead of var(--ink); (4) the body rule uses @apply bg-paper text-ink rather than direct var(--paper)/var(--ink) assignments; (5) app/page.tsx renders an <h1> with p-8 instead of the minimal <main className="container mx-auto p-14">Working with Me</main> placeholder. Bring the three files into compliance so AC-Tokens, AC-Tailwind-Resolves, AC-Manifest-Parity, and the layout 'no next/font / no providers / no client directive' behavior all pass.

## Changes
- `app/globals.css`
- `app/layout.tsx`
- `app/page.tsx`

## QA Results
- Security: PASS
- Correctness: PASS
- Architecture: PASS

## Design Review
**Verdict:** PASS

### Probes
- ✅ **P1** Primary screen communicates feature purpose \(placeholder is spec-mandated; meta description carries the intent statement\) — `app/page.tsx:2` (On-screen copy is intentionally minimal per Foundation 2/3 spec; the document.title and meta description at app/layout.tsx:5-6 \('A space to post Assignments, mark Commitments, and broadcast Connections.'\) carry purpose, matching AC-No-Font-Wiring and the brief's explicit endorsement of the placeho)
- ✅ **P2** Primary CTA label predicts next screen
- ✅ **P3** Async operations show progress
- ✅ **P4** Error → recovery specificity
- ✅ **P5** Destructive actions reversible
- ✅ **P6** Resumption state after tab close / idle — `app/page.tsx:1-3` (Stateless static Server Component; cold reload returns identical state. No persistence layer needed for this child.)
- ✅ **P7** Cross-entry consistency — `app/page.tsx:1` (Sole entry is /; anti-requirement forbids /profile, /me/inbox, /network in this child.)
- ✅ **P8** Stale-data staleness signal
- ✅ **P9** Mental-model alignment for domain terms \(Assignments / Commitments / Connections; --pill rename; --font-\* aliases\) — `app/layout.tsx:6` (Meta description uses public-vocabulary nouns \(capital A/C/C\) per Mental-Model Ledger; --pill rename consistent with spec at app/globals.css:22; --font-{sans,serif,mono} chains at app/globals.css:31-33 honor the dual-reference reconciliation \(next/font-first, system-fallback\) called out in the L)
- ✅ **P10** Blast radius of partial-failure interrupt — `app/page.tsx:1-3` (No persistence and no in-flight mutations in this child; tab-close at any moment loses nothing because nothing is being written.)

## Test Plan
Manual verification