### PR TITLE
Foundation 3/3: Vocabulary, identity helpers, README onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Working with Me
+# Working with me
 
-## Local development
+A small Next.js app that turns a Cardano stake address into a public
+profile. Visitors see a person's Assignments, Commitments, Connections,
+and Credentials in one place.
+
+## Local setup
 
 Prerequisites: pnpm 9, Node 20.
 
@@ -15,3 +19,44 @@ Other scripts:
 - `pnpm build` runs the production build.
 - `pnpm typecheck` runs `tsc --noEmit`.
 - `pnpm lint` runs Next lint.
+
+## Andamio prerequisites
+
+Fill these names in your `.env.local` after copying from `.env.example`.
+Reference the names only; never paste values into source or docs.
+
+- `ANDAMIO_API_KEY` is the credential the server uses to authenticate
+  outbound calls to the Andamio backend.
+- `ANDAMIO_GATEWAY_URL` is the base URL of the Andamio gateway this
+  app reads from.
+- `ANDAMIO_NETWORK` is the network selector that picks which Andamio
+  environment the app talks to.
+
+## Design references
+
+The design materials live under `docs/design/`. Read these before
+touching UI:
+
+- [docs/design/AGENT-NOTES.md](docs/design/AGENT-NOTES.md) is the
+  vocabulary, voice, and visual rules an agent or contributor must
+  follow.
+- [docs/design/README.md](docs/design/README.md) is the handoff bundle
+  that explains how the design references are organised.
+
+## Vocabulary and voice
+
+Use these user-facing nouns. They are also exported from
+`lib/copy/vocabulary.ts` so JSX never hard-codes labels.
+
+- Assignment, Assignments
+- Commitment, Commitments
+- Connection, Connections
+- Credential, Credentials
+- your space
+- more about how I work
+
+Voice rules:
+
+- No em-dashes. Use commas, periods, or parentheses.
+- Short sentences. Plain words.
+- No AI-slop tokens or filler phrasing.

--- a/lib/copy/vocabulary.ts
+++ b/lib/copy/vocabulary.ts
@@ -1,0 +1,29 @@
+/**
+ * Single source of user-facing nouns for this product.
+ *
+ * Every UI surface should import strings from `COPY` rather than hard-coding
+ * labels, so the vocabulary stays consistent and reviewable in one place.
+ *
+ * FORBIDDEN Andamio-internal terms that must never appear in user-facing copy:
+ *   - course
+ *   - module
+ *   - SLT
+ *   - student
+ *   - teacher
+ *   - assignment submission
+ *   - credential issuance
+ */
+export const COPY = Object.freeze({
+  assignment: 'Assignment',
+  assignments: 'Assignments',
+  commitment: 'Commitment',
+  commitments: 'Commitments',
+  connection: 'Connection',
+  connections: 'Connections',
+  credential: 'Credential',
+  credentials: 'Credentials',
+  yourSpace: 'your space',
+  moreAboutHowIWork: 'more about how I work',
+} as const);
+
+export type Copy = typeof COPY;

--- a/lib/identity/address.ts
+++ b/lib/identity/address.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure helpers for rendering Cardano stake addresses and display names.
+ *
+ * Zero external dependencies. No React, no fetch, no environment reads.
+ * Safe to import from server components, client components, or plain
+ * Node scripts.
+ */
+
+const ELLIPSIS = '…';
+const ANONYMOUS = 'Anonymous';
+
+export function shortAddress(
+  address: string,
+  opts?: { head?: number; tail?: number },
+): string {
+  if (address == null) return '';
+  if (typeof address !== 'string') return '';
+  const trimmed = address.trim();
+  if (trimmed.length === 0) return '';
+
+  const head = opts?.head ?? 8;
+  const tail = opts?.tail ?? 6;
+
+  if (trimmed.length <= head + tail + 1) return trimmed;
+
+  return `${trimmed.slice(0, head)}${ELLIPSIS}${trimmed.slice(trimmed.length - tail)}`;
+}
+
+export function displayName(
+  input: { stakeAddress?: string; handle?: string; name?: string } | null | undefined,
+): string {
+  if (input == null) return ANONYMOUS;
+
+  const name = input.name?.trim();
+  if (name) return name;
+
+  const handle = input.handle?.trim();
+  if (handle) return handle;
+
+  const stake = input.stakeAddress?.trim();
+  if (stake) {
+    const short = shortAddress(stake);
+    if (short) return short;
+  }
+
+  return ANONYMOUS;
+}


### PR DESCRIPTION
Closes #28

## Summary
The repo has no single source for user-facing nouns and no pure helpers for rendering Cardano stake addresses or display names, so downstream UI children would each invent their own. The README is a thin placeholder that does not describe the project, list the Andamio env-var prerequisites, or point new contributors at the design references. This child lands lib/copy/vocabulary.ts, lib/identity/address.ts, and a rewritten README.md so later children can import canonical copy and helpers, and so a new contributor can pnpm install and find their way to the design materials.

## Changes
- `README.md`
- `lib/copy/vocabulary.ts`
- `lib/identity/address.ts`

## QA Results
- Security: PASS
- Correctness: PASS
- Architecture: PASS

## Test Plan
Manual verification