### PR TITLE
UI primitives: CredentialToken, BrowserCard, ScreenCard

### DIFF
--- a/components/ui/BrowserCard.module.css
+++ b/components/ui/BrowserCard.module.css
@@ -1,0 +1,46 @@
+.root {
+  background: var(--paper-deep);
+  border: 1.25px solid var(--ink);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.top {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.dots {
+  display: flex;
+  gap: 5px;
+}
+
+.dot {
+  width: 9px;
+  height: 9px;
+  background: var(--rule);
+  border-radius: 50%;
+}
+
+.url {
+  flex-grow: 1;
+  padding: 6px 12px;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  border-radius: var(--pill);
+  font: 400 12px var(--font-mono);
+  color: var(--muted);
+  letter-spacing: -0.005em;
+}
+
+.url b {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.body {
+  padding: 36px 40px;
+}

--- a/components/ui/BrowserCard.tsx
+++ b/components/ui/BrowserCard.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import styles from './BrowserCard.module.css';
+
+type BrowserCardProps = {
+  url: string;
+  urlPrefix?: string;
+  rightSlot?: ReactNode;
+  children: ReactNode;
+};
+
+export default function BrowserCard({
+  url,
+  urlPrefix = 'workingwith.me/',
+  rightSlot,
+  children,
+}: BrowserCardProps) {
+  return (
+    <div className={styles.root}>
+      <div className={styles.top}>
+        <span className={styles.dots}>
+          <span className={styles.dot} />
+          <span className={styles.dot} />
+          <span className={styles.dot} />
+        </span>
+        <span className={styles.url}>
+          {urlPrefix}
+          <b>{url}</b>
+        </span>
+        {rightSlot}
+      </div>
+      <div className={styles.body}>{children}</div>
+    </div>
+  );
+}

--- a/components/ui/CredentialToken.module.css
+++ b/components/ui/CredentialToken.module.css
@@ -1,0 +1,164 @@
+.root {
+  position: relative;
+  width: 220px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: var(--paper);
+  border: 1.5px solid var(--ink);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  text-align: center;
+  font: 500 11px var(--font-mono);
+  color: var(--ink);
+  flex-shrink: 0;
+}
+
+.root::before,
+.root::after {
+  content: '';
+  position: absolute;
+  border: 1px solid var(--rule);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.root::before {
+  inset: 8px;
+}
+
+.root::after {
+  inset: 18px;
+}
+
+.id {
+  position: absolute;
+  top: 14px;
+  left: 14px;
+  font: 500 9px var(--font-mono);
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+
+.hdr {
+  font: 500 9px var(--font-mono);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.pair {
+  font: 400 13px/1.25 var(--font-serif);
+  font-style: italic;
+  color: var(--ink);
+  letter-spacing: -0.005em;
+  max-width: 14ch;
+}
+
+.ampersand {
+  display: block;
+  font: 400 28px var(--font-serif);
+  font-style: italic;
+  color: var(--signal);
+  margin: 4px 0;
+}
+
+.seal {
+  position: absolute;
+  width: 36px;
+  height: 36px;
+  background: var(--signal);
+  border-radius: 50%;
+  border: 1.5px solid var(--ink);
+  bottom: 14px;
+  right: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--paper);
+  font: 500 9px var(--font-mono);
+  letter-spacing: 0.04em;
+}
+
+/* small variant */
+.root.sm {
+  width: 84px;
+  padding: 10px;
+}
+
+.root.sm::before {
+  inset: 4px;
+}
+
+.root.sm::after {
+  inset: 10px;
+}
+
+.root.sm .hdr {
+  font-size: 7px;
+  margin-bottom: 2px;
+}
+
+.root.sm .pair {
+  font-size: 9px;
+  max-width: 10ch;
+}
+
+.root.sm .ampersand {
+  font-size: 14px;
+  margin: 1px 0;
+}
+
+.root.sm .seal {
+  width: 14px;
+  height: 14px;
+  bottom: 4px;
+  right: 4px;
+  font-size: 0;
+}
+
+.root.sm .id {
+  display: none;
+}
+
+/* deep variant — applies when component carries .deep OR ancestor has .deep */
+.root.deep {
+  background: var(--teal-deep);
+  border-color: var(--paper);
+  color: var(--paper);
+}
+
+.root.deep::before,
+.root.deep::after {
+  border-color: rgba(244, 239, 230, 0.18);
+}
+
+.root.deep .hdr {
+  color: var(--on-deep-mute);
+}
+
+.root.deep .pair {
+  color: var(--paper);
+}
+
+:global(.deep) .root {
+  background: var(--teal-deep);
+  border-color: var(--paper);
+  color: var(--paper);
+}
+
+:global(.deep) .root::before,
+:global(.deep) .root::after {
+  border-color: rgba(244, 239, 230, 0.18);
+}
+
+:global(.deep) .root .hdr {
+  color: var(--on-deep-mute);
+}
+
+:global(.deep) .root .pair {
+  color: var(--paper);
+}

--- a/components/ui/CredentialToken.tsx
+++ b/components/ui/CredentialToken.tsx
@@ -1,0 +1,43 @@
+import styles from './CredentialToken.module.css';
+
+type CredentialTokenProps = {
+  partyA: string;
+  partyB: string;
+  id?: string;
+  size?: 'default' | 'sm';
+  variant?: 'default' | 'deep';
+  sealLabel?: string;
+};
+
+export default function CredentialToken({
+  partyA,
+  partyB,
+  id,
+  size = 'default',
+  variant = 'default',
+  sealLabel,
+}: CredentialTokenProps) {
+  const firstA = partyA.split(' ')[0];
+  const firstB = partyB.split(' ')[0];
+
+  const classes = [
+    styles.root,
+    size === 'sm' ? styles.sm : '',
+    variant === 'deep' ? styles.deep : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes}>
+      {id && <span className={styles.id}>{id}</span>}
+      <span className={styles.hdr}>Connection</span>
+      <span className={styles.pair}>
+        {firstA}
+        <span className={styles.ampersand}>&amp;</span>
+        {firstB}
+      </span>
+      <span className={styles.seal}>{sealLabel}</span>
+    </div>
+  );
+}

--- a/components/ui/ScreenCard.module.css
+++ b/components/ui/ScreenCard.module.css
@@ -1,0 +1,35 @@
+.root {
+  background: var(--paper);
+  color: var(--ink);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.top {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.crumb {
+  font: 500 12px var(--font-sans);
+  color: var(--muted);
+  letter-spacing: -0.005em;
+}
+
+.crumb b {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.badge {
+  font: 500 11px var(--font-mono);
+  color: var(--teal);
+  letter-spacing: -0.005em;
+}
+
+.body {
+  padding: 22px 24px;
+}

--- a/components/ui/ScreenCard.tsx
+++ b/components/ui/ScreenCard.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+import styles from './ScreenCard.module.css';
+
+type ScreenCardProps = {
+  crumb: ReactNode;
+  badge?: ReactNode;
+  children: ReactNode;
+};
+
+export default function ScreenCard({ crumb, badge, children }: ScreenCardProps) {
+  return (
+    <div className={styles.root}>
+      <div className={styles.top}>
+        <span className={styles.crumb}>{crumb}</span>
+        {badge !== undefined && <span className={styles.badge}>{badge}</span>}
+      </div>
+      <div className={styles.body}>{children}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #30

## Summary
Three of the four V1 design system components are visual primitives that render structural chrome around content: CredentialToken (the recurring brand artifact with concentric ring pseudo-elements + ampersand + signal seal), BrowserCard (mock browser chrome for Assignment renders), and ScreenCard (full-bleed product-screen card). Downstream landing-page, profile, inbox, and gated-unlock children cannot ship without these reusable React versions. They share enough structural similarity (token-bound colors, server components, tight prop APIs) to ship in one PR. The components/ui/ directory does not yet exist in the repo — this PR establishes it.

## Changes
- `components/ui/BrowserCard.module.css`
- `components/ui/BrowserCard.tsx`
- `components/ui/CredentialToken.module.css`
- `components/ui/CredentialToken.tsx`
- `components/ui/ScreenCard.module.css`
- `components/ui/ScreenCard.tsx`

## QA Results
- Security: PASS
- Correctness: PASS
- Architecture: PASS

## Design Review
**Verdict:** PASS

### Probes
- ✅ **P1** Primary surface communicates feature purpose — CredentialToken's user-facing 'Connection' headline reconciles engineer-name 'CredentialToken' with the Mental-Model Ledger entry that user-meaning is a relationship artifact, not an auth secret. BrowserCard/ScreenCard are non-semantic chrome wrappers; their purpose comes from caller content. — `components/ui/CredentialToken.tsx:34`
- ✅ **P2** Intention → action mapping not applicable: none of the three primitives renders a CTA, link, or button. Confirmed via grep: no '\<button' / no '\<a ' / no onClick anywhere in the three TSX files.
- ✅ **P3** Execution feedback latency not applicable: no async operations, no Suspense boundaries, no fetch, no promise-returning props. All three components are pure render-time markup.
- ✅ **P4** Error → recovery specificity not applicable: no error states, no input handling, no failure branches. These primitives have no operation that can fail.
- ✅ **P5** Reversibility not applicable: no destructive actions exist. No mutation, no submit, no delete affordance.
- ✅ **P6** Resumption not applicable: server components with zero internal state. Each render is fresh from props; no cache, no persistence layer involved at the primitive level.
- ✅ **P7** Cross-entry consistency not applicable: primitives have no routing entry points. They are imported and rendered by callers; consistency is the caller's responsibility.
- ✅ **P8** Stale-data staleness not applicable: no internal data binding. ScreenCard.badge and BrowserCard.url accept ReactNode/string from caller; staleness is caller-owned per the brief's Mental-Model Ledger \('ScreenCard is staleness-agnostic'\). — `components/ui/ScreenCard.tsx:15`
- ✅ **P9** Mental-model alignment present: the brief's Ledger flags 'Credential'/'Token'/'Connection' divergence; implementation hard-codes the visible headline as 'Connection' \(uppercased via CSS text-transform per spec\), not 'Credential' or 'Token'. The component name is engineer-facing only, never appears in JSX text. No Andamio-internal vocabulary leaked into JSX \(no 'course', 'student', 'submission', — `components/ui/CredentialToken.tsx:34`
- ✅ **P10** Blast radius of interrupt not applicable: no save operation, no partial state, no in-flight work. A tab close mid-render simply unmounts the component tree.

### Findings
- **[INFO]** [AC-17c] Conditional slot omission honored exactly: ScreenCard uses \`badge \!== undefined\` so \`null\`/\`0\`/empty-string still render a span — matches the strict spec wording \('omitted when undefined'\). BrowserCard renders \`{rightSlot}\` directly with no wrapper, so falsy values produce zero DOM nodes. Both behaviors track the brief's interaction invariants. — `components/ui/ScreenCard.tsx:15` _fix: No change needed — confirms spec compliance._
- **[INFO]** [AC-17c] CredentialToken always renders the seal \`\<span\>\` regardless of \`sealLabel\`. Correct behavior: the seal disc itself is the visual element \(coral 36×36 circle in default; 14×14 in sm\), and \`sealLabel\` is only the inner glyph. The sm CSS sets \`font-size: 0\` to hide any label text while preserving the disc — matches base.css:340 and the brief's row 'sm size hides id and seal LABEL'. — `components/ui/CredentialToken.tsx:40` _fix: No change needed._
- **[INFO]** [AC-17c] Deep variant correctly implements both selectors: \`.root.deep\` \(lines 128-145\) for standalone \`variant='deep'\` AND \`:global\(.deep\) .root\` \(lines 147-164\) for legacy ancestor parity per base.css:344-352. Pseudo-element rings declare \`content: ''\` and \`pointer-events: none\` \(lines 21,25\) — both easy-to-omit details from the brief's risk list are present. — `components/ui/CredentialToken.module.css:147` _fix: No change needed._

## Test Plan
Manual verification