### PR TITLE
Bring six agency/11 UI primitives into agency/32 working tree

### DIFF
--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -1,0 +1,80 @@
+import type { CSSProperties } from "react";
+
+export type AvatarSize = "sm" | "default" | "lg";
+
+export interface AvatarProps {
+  /**
+   * Display name. Only the first character of the first whitespace-split word
+   * is rendered as an uppercase initial. Empty / whitespace / undefined falls
+   * back to a single placeholder character without throwing.
+   */
+  name?: string;
+  size?: AvatarSize;
+  /**
+   * Background override. Pass a CSS variable reference such as
+   * `var(--teal-deep)`; raw hex strings violate the design contract.
+   */
+  bg?: string;
+  className?: string;
+}
+
+const PLACEHOLDER = "?";
+
+const sizeMap: Record<AvatarSize, { box: number; font: number }> = {
+  sm: { box: 24, font: 10 },
+  default: { box: 32, font: 12 },
+  lg: { box: 56, font: 18 },
+};
+
+const initialFor = (name: string | undefined): string => {
+  if (typeof name !== "string") return PLACEHOLDER;
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return PLACEHOLDER;
+  const first = trimmed.split(/\s+/)[0];
+  const ch = [...first][0];
+  return ch ? ch.toUpperCase() : PLACEHOLDER;
+};
+
+export function Avatar({
+  name,
+  size = "default",
+  bg,
+  className,
+}: AvatarProps) {
+  const { box, font } = sizeMap[size];
+  const sizeClass = size === "default" ? "" : size;
+  const classes = ["avatar", sizeClass, className].filter(Boolean).join(" ");
+
+  const style: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: box,
+    height: box,
+    background: bg ?? "var(--teal)",
+    color: "var(--paper)",
+    fontFamily: "var(--sans)",
+    fontWeight: 500,
+    fontSize: font,
+    letterSpacing: "-0.01em",
+    borderRadius: "50%",
+    flexShrink: 0,
+  };
+
+  const trimmedName = typeof name === "string" ? name.trim() : "";
+  const hasName = trimmedName.length > 0;
+
+  return (
+    <span
+      className={classes}
+      style={style}
+      role={hasName ? "img" : undefined}
+      aria-label={hasName ? trimmedName : undefined}
+      aria-hidden={hasName ? undefined : true}
+    >
+      {initialFor(name)}
+    </span>
+  );
+}
+
+export default Avatar;

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,114 @@
+import type { ButtonHTMLAttributes, CSSProperties, ReactNode } from "react";
+
+export type ButtonVariant = "pri" | "out" | "ghost" | "cream" | "cream-out";
+export type ButtonSize = "sm" | "default";
+
+/**
+ * Pill-shaped button primitive. Server-renderable React component.
+ *
+ * Usage notes:
+ * - Variant names map to the `.btn-pri | .btn-out | .btn-ghost | .btn-cream |
+ *   .btn-cream-out` class suffixes mirrored from the design source. Hover and
+ *   `:focus-visible` styling lives in the foundation-owned globals.css; this
+ *   component emits the matching className suffixes so foundation CSS resolves.
+ * - Button is server-renderable: do NOT promote it to a Client Component.
+ *   `onClick` forwards as a normal HTML attribute and only fires when the
+ *   consuming component is itself a Client Component (the closure is created
+ *   on the client). If a downstream handler is not firing, mark the consumer
+ *   as a Client Component — never this primitive.
+ */
+export interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  children?: ReactNode;
+}
+
+const baseStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "12px 20px",
+  fontFamily: "var(--sans)",
+  fontWeight: 500,
+  fontSize: 14,
+  lineHeight: 1,
+  letterSpacing: "-0.005em",
+  border: "1.25px solid transparent",
+  borderRadius: "var(--pill, 999px)",
+  cursor: "pointer",
+  transition:
+    "background var(--motion-fast, 160ms), color var(--motion-fast, 160ms), border-color var(--motion-fast, 160ms)",
+};
+
+const smStyle: CSSProperties = { padding: "8px 14px", fontSize: 13 };
+
+const variantStyle: Record<ButtonVariant, CSSProperties> = {
+  pri: {
+    background: "var(--ink)",
+    color: "var(--paper)",
+    borderColor: "var(--ink)",
+  },
+  out: {
+    background: "transparent",
+    color: "var(--ink)",
+    borderColor: "var(--ink)",
+  },
+  ghost: {
+    background: "transparent",
+    color: "var(--ink)",
+    borderColor: "var(--rule)",
+  },
+  cream: {
+    background: "var(--paper)",
+    color: "var(--ink)",
+    borderColor: "var(--paper)",
+  },
+  "cream-out": {
+    background: "transparent",
+    color: "var(--paper)",
+    borderColor: "var(--on-deep-mute)",
+  },
+};
+
+const disabledStyle: CSSProperties = {
+  opacity: 0.5,
+  cursor: "not-allowed",
+};
+
+export function Button({
+  variant = "pri",
+  size = "default",
+  className,
+  type = "button",
+  style,
+  disabled,
+  children,
+  ...rest
+}: ButtonProps) {
+  const classes = ["btn", `btn-${variant}`, size === "sm" ? "btn-sm" : "", className]
+    .filter(Boolean)
+    .join(" ");
+
+  const merged: CSSProperties = {
+    ...baseStyle,
+    ...variantStyle[variant],
+    ...(size === "sm" ? smStyle : {}),
+    ...(disabled ? disabledStyle : {}),
+    ...style,
+  };
+
+  return (
+    <button
+      {...rest}
+      type={type}
+      disabled={disabled}
+      className={classes}
+      style={merged}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default Button;

--- a/components/ui/FaqRow.tsx
+++ b/components/ui/FaqRow.tsx
@@ -1,0 +1,51 @@
+import type { CSSProperties, ReactNode } from "react";
+
+export interface FaqRowProps {
+  question: ReactNode;
+  answer: ReactNode;
+  className?: string;
+}
+
+const rowStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "minmax(0, 0.9fr) minmax(0, 1.6fr)",
+  gap: 56,
+  padding: "28px 0",
+  borderBottom: "1px solid var(--rule)",
+  alignItems: "baseline",
+};
+
+const questionStyle: CSSProperties = {
+  fontFamily: "var(--sans)",
+  fontWeight: 500,
+  fontSize: 19,
+  lineHeight: 1.3,
+  letterSpacing: "-0.015em",
+  color: "var(--ink)",
+};
+
+const answerStyle: CSSProperties = {
+  fontFamily: "var(--sans)",
+  fontWeight: 400,
+  fontSize: 16,
+  lineHeight: 1.65,
+  letterSpacing: "-0.005em",
+  color: "var(--muted)",
+  maxWidth: "64ch",
+};
+
+export function FaqRow({ question, answer, className }: FaqRowProps) {
+  const classes = ["faq-row", className].filter(Boolean).join(" ");
+  return (
+    <div className={classes} style={rowStyle}>
+      <div className="q" style={questionStyle}>
+        {question}
+      </div>
+      <div className="a" style={answerStyle}>
+        {answer}
+      </div>
+    </div>
+  );
+}
+
+export default FaqRow;

--- a/components/ui/Label.tsx
+++ b/components/ui/Label.tsx
@@ -1,0 +1,73 @@
+import type { CSSProperties, ReactNode } from "react";
+
+export type LabelVariant = "default" | "muted" | "ink" | "cream";
+
+export interface LabelProps {
+  /**
+   * Color variant. Pick by surface intent, not by color name:
+   * - `default` — teal-soft text on the standard paper surface
+   * - `muted` — quieter eyebrow text on the standard paper surface
+   * - `ink` — strongest eyebrow text on the standard paper surface
+   * - `cream` — for placement on deep/dark surfaces (e.g. `--teal-deep`); the
+   *   leading dot color shifts from `--signal` to `--signal-soft` to stay legible
+   */
+  variant?: LabelVariant;
+  /** Show the leading 6px signal dot. Defaults to true (opt-OUT, not opt-IN). */
+  dot?: boolean;
+  className?: string;
+  children?: ReactNode;
+}
+
+const baseStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 10,
+  fontFamily: "var(--sans)",
+  fontWeight: 500,
+  fontSize: 12,
+  lineHeight: 1,
+  letterSpacing: "0.04em",
+  textTransform: "none",
+};
+
+const variantColor: Record<LabelVariant, string> = {
+  default: "var(--teal-soft)",
+  muted: "var(--muted)",
+  ink: "var(--ink)",
+  cream: "var(--on-deep)",
+};
+
+const dotBgFor = (variant: LabelVariant): string =>
+  variant === "cream" ? "var(--signal-soft)" : "var(--signal)";
+
+const dotStyle = (variant: LabelVariant): CSSProperties => ({
+  width: 6,
+  height: 6,
+  background: dotBgFor(variant),
+  borderRadius: "50%",
+  display: "inline-block",
+  flexShrink: 0,
+});
+
+export function Label({
+  variant = "default",
+  dot = true,
+  className,
+  children,
+}: LabelProps) {
+  const variantClass =
+    variant === "default" ? "label" : `label ${variant}`;
+  const classes = [variantClass, className].filter(Boolean).join(" ");
+
+  return (
+    <span
+      className={classes}
+      style={{ ...baseStyle, color: variantColor[variant] }}
+    >
+      {dot ? <span className="dot" style={dotStyle(variant)} /> : null}
+      {children}
+    </span>
+  );
+}
+
+export default Label;

--- a/components/ui/MonoTag.tsx
+++ b/components/ui/MonoTag.tsx
@@ -1,0 +1,26 @@
+import type { CSSProperties, ReactNode } from "react";
+
+export interface MonoTagProps {
+  className?: string;
+  children?: ReactNode;
+}
+
+const baseStyle: CSSProperties = {
+  fontFamily: "var(--mono)",
+  fontWeight: 500,
+  fontSize: 11,
+  lineHeight: 1,
+  letterSpacing: "0.02em",
+  color: "var(--muted)",
+};
+
+export function MonoTag({ className, children }: MonoTagProps) {
+  const classes = ["mono-tag", className].filter(Boolean).join(" ");
+  return (
+    <span className={classes} style={baseStyle}>
+      {children}
+    </span>
+  );
+}
+
+export default MonoTag;

--- a/components/ui/SignalWave.tsx
+++ b/components/ui/SignalWave.tsx
@@ -1,0 +1,38 @@
+import type { CSSProperties } from "react";
+
+export interface SignalWaveProps {
+  className?: string;
+}
+
+const HEIGHTS = ["30%", "65%", "100%", "75%", "45%", "60%", "35%"] as const;
+
+const containerStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 3,
+  height: 18,
+};
+
+const barBaseStyle: CSSProperties = {
+  width: 3,
+  background: "currentColor",
+  borderRadius: 1,
+  opacity: 0.85,
+};
+
+export function SignalWave({ className }: SignalWaveProps) {
+  const classes = ["signal-wave", className].filter(Boolean).join(" ");
+  return (
+    <span className={classes} style={containerStyle} aria-hidden="true">
+      {HEIGHTS.map((height) => (
+        <span
+          key={height}
+          className="b"
+          style={{ ...barBaseStyle, height }}
+        />
+      ))}
+    </span>
+  );
+}
+
+export default SignalWave;


### PR DESCRIPTION
Closes #55

## Summary
agency/48's downstream foundation work and V1 composition cannot proceed until six UI primitives (Button, Label, MonoTag, Avatar, SignalWave, FaqRow) exist in the working tree. They currently live only on agency/11. This child performs a targeted `git checkout agency/11 -- <paths>` to bring those six files in byte-identical, while leaving the existing #47 primitives (CredentialToken, BrowserCard, ScreenCard and their .module.css siblings) untouched. The sibling child #2 will then add the .eslintrc.json and run the typecheck/verification gate against the merged tree.

## Changes
- `components/ui/Avatar.tsx`
- `components/ui/Button.tsx`
- `components/ui/FaqRow.tsx`
- `components/ui/Label.tsx`
- `components/ui/MonoTag.tsx`
- `components/ui/SignalWave.tsx`

## QA Results
- Security: PASS
- Correctness: PASS
- Architecture: PASS

## Design Review
**Verdict:** PASS

### Probes
- ✅ **P1** Goal of each primitive is communicated to its consumer \(the developer-user\) via JSDoc + exported types — `components/ui/Button.tsx:6` (Button.tsx:6-19 + Label.tsx:6-13 + Avatar.tsx:6-19 carry purpose, surface-intent, and contract notes \(e.g. 'raw hex strings violate the design contract'\). No end-user 'primary screen' exists — this child is an infrastructure import.)
- ✅ **P2** CTA-label predicts target screen
- ✅ **P3** Async operations show progress / disabled state
- ✅ **P4** Each error class names a concrete recovery
- ✅ **P5** Destructive actions are reversible/confirmed
- ✅ **P6** User can resume after tab close / 10 day idle
- ✅ **P7** Cross-entry consistency
- ✅ **P8** Stale-data signal
- ✅ **P9** Domain terms whose user-meaning differs from system-meaning are reconciled — `components/ui/Label.tsx:6` (Per the brief's Mental-Model Ledger: Label.tsx:6-13 explicitly reconciles \`cream\` as 'placement on deep/dark surfaces' rather than 'cream-colored eyebrow', and documents the dot color shift to --signal-soft. Label.tsx:15 reconciles \`dot\` as opt-OUT \(defaults true\). Avatar.tsx:13-16 reconciles )
- ✅ **P10** Blast radius of mid-flight interrupt

### Findings
- **[INFO]** [no AC affected] FaqRow renders Q/A as \`\<div class='q'\>\` and \`\<div class='a'\>\` \(FaqRow.tsx:41-46\) with no list-pair semantics \(no \<dl\>/\<dt\>/\<dd\>, no heading on the question, no aria-labelledby\). Screen-reader users will hear three plain divs rather than a Q&A pair. NOT actionable in this PR — the byte-identity invariant + anti-req 'Must NOT amend the brought-in primitives' forbid fixing it here. File upstream against agency/11 so a future revision lands the semantic markup before this primitive — `components/ui/FaqRow.tsx:39` _fix: Upstream-only: convert FaqRow root to \<dl\> with \<dt\>/\<dd\>, or wrap question in a heading element with id + answer with aria-labelledby._
- **[INFO]** [no AC affected] Button declares no inline \`:focus-visible\` style \(Button.tsx:27-77\) — keyboard focus relies entirely on foundation globals.css \`.btn-\*\` rules, which are not yet wired in this tree. Consistent with the plan's 'unstyled in isolation is expected' note, but worth tracking: if the foundation child does not ship a focus-visible ring under \`.btn\`, the merged surface is a keyboard-accessibility regression. Verify in the sibling foundation PR. — `components/ui/Button.tsx:27` _fix: Sibling foundation child must define \`.btn:focus-visible { outline: 2px solid var\(--ink\); outline-offset: 2px }\` \(or equivalent token-driven ring\) in globals.css._
- **[INFO]** [no AC affected] Two CSS variables referenced by the brought-in primitives are NOT in the brief's enumerated foundation-token list: \`var\(--teal\)\` \(Avatar.tsx:54, default bg\) and \`var\(--on-deep-mute\)\` \(Button.tsx:70, cream-out borderColor\). The brief's Interaction Invariants enumerates --ink/--paper/--rule/--pill/--motion-fast/--sans/--mono/--muted/--teal-deep/--teal-soft/--signal/--signal-soft/--on-deep — but not --teal or --on-deep-mute. If the sibling foundation child does not define these, Avatar  — `components/ui/Avatar.tsx:54` _fix: Sibling foundation child: confirm globals.css defines --teal and --on-deep-mute \(or alias them\). Do not patch primitives._

## Test Plan
Manual verification