### PR TITLE
UI primitives polish: JSDoc contracts + Label dot a11y

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -8,9 +8,14 @@ export type ButtonSize = "sm" | "default";
  *
  * Usage notes:
  * - Variant names map to the `.btn-pri | .btn-out | .btn-ghost | .btn-cream |
- *   .btn-cream-out` class suffixes mirrored from the design source. Hover and
- *   `:focus-visible` styling lives in the foundation-owned globals.css; this
+ *   .btn-cream-out` class suffixes mirrored from the design source. This
  *   component emits the matching className suffixes so foundation CSS resolves.
+ * - Focus ring contract: the `:focus-visible` outline is owned by the
+ *   foundation file `app/globals.css` — specifically the generic
+ *   `:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }`
+ *   rule in the base layer, which applies to the rendered `<button>` element.
+ *   No `.btn`-scoped focus selector exists; edit `app/globals.css` to change
+ *   the focus ring, never this component.
  * - Button is server-renderable: do NOT promote it to a Client Component.
  *   `onClick` forwards as a normal HTML attribute and only fires when the
  *   consuming component is itself a Client Component (the closure is created

--- a/components/ui/Label.tsx
+++ b/components/ui/Label.tsx
@@ -64,7 +64,7 @@ export function Label({
       className={classes}
       style={{ ...baseStyle, color: variantColor[variant] }}
     >
-      {dot ? <span className="dot" style={dotStyle(variant)} /> : null}
+      {dot ? <span className="dot" style={dotStyle(variant)} aria-hidden="true" /> : null}
       {children}
     </span>
   );

--- a/components/ui/SignalWave.tsx
+++ b/components/ui/SignalWave.tsx
@@ -1,5 +1,16 @@
 import type { CSSProperties } from "react";
 
+/**
+ * Decorative bar-cluster signal indicator.
+ *
+ * Color contract:
+ * - The bars paint via `background: currentColor`, so the rendered color is
+ *   inherited from the closest ancestor that sets the CSS `color` property.
+ * - To recolor, wrap `<SignalWave />` in an element that sets `color`
+ *   (e.g. `<span style={{ color: "var(--signal)" }}><SignalWave /></span>`).
+ * - A `color` prop is intentionally absent from this contract and MUST NOT
+ *   be added in future revisions — `currentColor` IS the recoloring API.
+ */
 export interface SignalWaveProps {
   className?: string;
 }


### PR DESCRIPTION
Closes #58

## Summary
Three UI primitives shipped in #57 without the API-contract documentation and accessibility hint flagged by the agency/11 design review (iteration 2/2). `SignalWaveProps` (components/ui/SignalWave.tsx:3-5) has no JSDoc explaining that color flows via `currentColor` (line 18: `background: "currentColor"`), so downstream consumers will likely wrap it in inline-style spans or request a `color` prop. `Button.tsx` has an existing JSDoc (lines 6-19) that mentions `:focus-visible` lives in globals.css but does not name the foundation file path or the actual selector explicitly enough to be a binding contract. The Label leading-dot `<span className="dot">` at components/ui/Label.tsx:67 is decorative but lacks `aria-hidden="true"`, exposing it to assistive tech. Pure docs + a11y polish — zero functional change to rendered DOM other than the new aria attribute, which screen readers honor but renders identically.

## Changes
- `components/ui/Button.tsx`
- `components/ui/Label.tsx`
- `components/ui/SignalWave.tsx`

## QA Results
- Security: PASS
- Correctness: PASS
- Architecture: PASS

## Design Review
**Verdict:** PASS

### Probes
- ✅ **P1** Primary screen communicates feature purpose — N/A: change is JSDoc + a11y polish on three primitives, no new user-facing screen or copy
- ✅ **P2** Primary CTA label predicts next screen — N/A: no CTA introduced; Button primitive's variant/label semantics unchanged
- ✅ **P3** Async operations show progress — N/A: no async paths added; pure docs + aria-hidden
- ✅ **P4** Error → Recovery specificity — N/A: no error branches introduced
- ✅ **P5** Reversibility — N/A: no destructive action introduced
- ✅ **P6** Resumption — N/A: primitives are stateless presentational components
- ✅ **P7** Cross-entry consistency — N/A: primitives have no entry point of their own
- ✅ **P8** Stale-data staleness — N/A: no data fetching
- ✅ **P9** Mental-model alignment — three Ledger entries are reconciled in code/docs: 'color' on SignalWave is reconciled to \`currentColor\` and explicitly forbids a \`color\` prop; ':focus-visible' on Button is reconciled to the actual generic rule in app/globals.css with no invented \`.btn:focus-visible\` selector; 'dot' on Label is marked decorative via \`aria-hidden="true"\` so AT only hears \`{children — `components/ui/SignalWave.tsx:3-13` (Cross-confirmed: Button.tsx:13-18 cites app/globals.css and the exact rule that exists at app/globals.css:57-60; Label.tsx:67 carries aria-hidden="true" only on the conditionally-rendered dot span, so dot={false} branch is unaffected.)
- ✅ **P10** Blast radius of interrupt — N/A: no save/network paths affected

### Findings
- **[INFO]** [AC-1] SignalWave JSDoc explicitly names \`currentColor\`, gives a wrap-to-recolor example, and forbids adding a \`color\` prop in future revisions — satisfies AC-1 cleanly. — `components/ui/SignalWave.tsx:3-13` _fix: No change needed._
- **[INFO]** [AC-2] Button JSDoc extension cites \`app/globals.css\` by path AND quotes the actual generic \`:focus-visible { outline: 2px solid var\(--ink\); outline-offset: 2px; }\` rule that exists at app/globals.css:57-60 — does not invent a \`.btn:focus-visible\` selector. Existing variant-suffix and server-component notes are preserved at lines 10-12 and 19-23. — `components/ui/Button.tsx:13-18` _fix: No change needed._
- **[INFO]** [AC-3] \`aria-hidden="true"\` is applied only to the dot span and only inside the truthy branch of the \`dot ? ... : null\` ternary, so a Label rendered with \`dot={false}\` produces no dot span and no leaked aria attribute. Eyebrow text in \`{children}\` remains the only spoken content. — `components/ui/Label.tsx:67` _fix: No change needed._
- **[INFO]** [AC-5] Diff is confined exactly to \(a\) JSDoc additions in SignalWave.tsx and Button.tsx and \(b\) one \`aria-hidden="true"\` JSX attribute on the Label dot span. No className, style, type, or imported-symbol drift; public TS API surface \(\`SignalWaveProps\`, \`ButtonProps\`, \`LabelProps\`, variants/sizes\) is byte-identical. — `components/ui/Label.tsx:67` _fix: No change needed._

## Test Plan
Manual verification