### PR TITLE
Server-side gateway proxy + session helpers

### DIFF
--- a/app/api/gateway/[...path]/route.ts
+++ b/app/api/gateway/[...path]/route.ts
@@ -1,0 +1,60 @@
+import 'server-only';
+
+import { isAllowed } from '@/lib/gateway/allowlist';
+import { gatewayFetch } from '@/lib/gateway/server';
+import { getSession } from '@/lib/session';
+
+type RouteContext = {
+  params: Promise<{ path: string[] }>;
+};
+
+async function handle(
+  request: Request,
+  context: RouteContext,
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+): Promise<Response> {
+  const { path } = await context.params;
+  const basePath = `/${path.join('/')}`;
+  const search = new URL(request.url).search;
+  const fullPath = `${basePath}${search}`;
+
+  if (!isAllowed(method, basePath)) {
+    return new Response(null, { status: 404 });
+  }
+
+  const session = await getSession();
+
+  const headers = new Headers();
+  const contentType = request.headers.get('content-type');
+  if (contentType) headers.set('content-type', contentType);
+  const accept = request.headers.get('accept');
+  if (accept) headers.set('accept', accept);
+
+  const body =
+    method === 'GET' || method === 'DELETE'
+      ? undefined
+      : await request.arrayBuffer();
+
+  return gatewayFetch(fullPath, {
+    method,
+    headers,
+    body,
+    jwt: session?.jwt,
+  });
+}
+
+export async function GET(request: Request, context: RouteContext) {
+  return handle(request, context, 'GET');
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  return handle(request, context, 'POST');
+}
+
+export async function PUT(request: Request, context: RouteContext) {
+  return handle(request, context, 'PUT');
+}
+
+export async function DELETE(request: Request, context: RouteContext) {
+  return handle(request, context, 'DELETE');
+}

--- a/lib/gateway/server.test.ts
+++ b/lib/gateway/server.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, mock, test, beforeEach } from 'bun:test';
+
+mock.module('server-only', () => ({}));
+
+process.env.ANDAMIO_API_KEY = 'test-api-key';
+process.env.ANDAMIO_GATEWAY_URL = 'https://gateway.example.test';
+
+const { gatewayFetch } = await import('./server');
+
+const ALLOWED_GET_PATH = '/api/v2/course/owner/courses/list';
+const ALLOWED_POST_PATH = '/api/v2/auth/login/session';
+
+type FetchCall = [string, RequestInit];
+
+function installFetchMock() {
+  const calls: FetchCall[] = [];
+  const fetchMock = mock(async (input: string, init: RequestInit = {}) => {
+    calls.push([input, init]);
+    return new Response(null, { status: 200 });
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return { calls, fetchMock };
+}
+
+describe('gatewayFetch', () => {
+  beforeEach(() => {
+    delete (globalThis as { fetch?: unknown }).fetch;
+  });
+
+  test('returns 404 and never calls upstream when path is not allowlisted', async () => {
+    const { calls } = installFetchMock();
+
+    const res = await gatewayFetch('/api/v2/not/a/real/route', { method: 'GET' });
+
+    expect(res.status).toBe(404);
+    expect(calls.length).toBe(0);
+  });
+
+  test('returns 404 when method does not match an allowlisted route', async () => {
+    const { calls } = installFetchMock();
+
+    const res = await gatewayFetch(ALLOWED_GET_PATH, { method: 'POST' });
+
+    expect(res.status).toBe(404);
+    expect(calls.length).toBe(0);
+  });
+
+  test('forwards allowlisted request with X-API-Key header injected', async () => {
+    const { calls } = installFetchMock();
+
+    await gatewayFetch(ALLOWED_GET_PATH, { method: 'GET' });
+
+    expect(calls.length).toBe(1);
+    const [url, init] = calls[0];
+    expect(url).toBe(`https://gateway.example.test${ALLOWED_GET_PATH}`);
+    const headers = new Headers(init.headers);
+    expect(headers.get('x-api-key')).toBe('test-api-key');
+  });
+
+  test('sets Authorization: Bearer <jwt> when init.jwt is provided', async () => {
+    const { calls } = installFetchMock();
+
+    await gatewayFetch(ALLOWED_GET_PATH, { method: 'GET', jwt: 'jwt-token-abc' });
+
+    expect(calls.length).toBe(1);
+    const headers = new Headers(calls[0][1].headers);
+    expect(headers.get('authorization')).toBe('Bearer jwt-token-abc');
+  });
+
+  test('omits Authorization header when init.jwt is not provided', async () => {
+    const { calls } = installFetchMock();
+
+    await gatewayFetch(ALLOWED_GET_PATH, { method: 'GET' });
+
+    expect(calls.length).toBe(1);
+    const headers = new Headers(calls[0][1].headers);
+    expect(headers.has('authorization')).toBe(false);
+  });
+
+  test('forwards method and body to upstream untouched', async () => {
+    const { calls } = installFetchMock();
+
+    const body = JSON.stringify({ stakeAddress: 'stake1u...' });
+    await gatewayFetch(ALLOWED_POST_PATH, {
+      method: 'POST',
+      body,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    expect(calls.length).toBe(1);
+    const [url, init] = calls[0];
+    expect(url).toBe(`https://gateway.example.test${ALLOWED_POST_PATH}`);
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(body);
+  });
+
+  test('rejects encoded-slash widening attempts (defers to allowlist hardening)', async () => {
+    const { calls } = installFetchMock();
+
+    const res = await gatewayFetch('/api/v2/course/detail/abc%2F123', { method: 'GET' });
+
+    expect(res.status).toBe(404);
+    expect(calls.length).toBe(0);
+  });
+
+  test('allows path-template match for /api/v2/course/detail/{courseId}', async () => {
+    const { calls } = installFetchMock();
+
+    await gatewayFetch('/api/v2/course/detail/course-xyz', { method: 'GET' });
+
+    expect(calls.length).toBe(1);
+    expect(calls[0][0]).toBe('https://gateway.example.test/api/v2/course/detail/course-xyz');
+  });
+});

--- a/lib/gateway/server.ts
+++ b/lib/gateway/server.ts
@@ -1,0 +1,37 @@
+import 'server-only';
+
+import { env } from '@/lib/env';
+import { isAllowed } from '@/lib/gateway/allowlist';
+
+export type GatewayFetchInit = {
+  method?: string;
+  headers?: HeadersInit;
+  body?: BodyInit;
+  jwt?: string;
+};
+
+export async function gatewayFetch(
+  path: string,
+  init?: GatewayFetchInit,
+): Promise<Response> {
+  const method = (init?.method ?? 'GET').toUpperCase();
+  const pathOnly = path.split('?')[0];
+
+  if (!isAllowed(method, pathOnly)) {
+    return new Response(null, { status: 404 });
+  }
+
+  const headers = new Headers(init?.headers);
+  headers.set('X-API-Key', env.ANDAMIO_API_KEY);
+  if (init?.jwt) {
+    headers.set('Authorization', `Bearer ${init.jwt}`);
+  }
+
+  const url = `${env.ANDAMIO_GATEWAY_URL}${path}`;
+
+  return fetch(url, {
+    method,
+    headers,
+    body: init?.body,
+  });
+}

--- a/lib/gateway/server.ts
+++ b/lib/gateway/server.ts
@@ -1,6 +1,5 @@
 import 'server-only';
 
-import { env } from '@/lib/env';
 import { isAllowed } from '@/lib/gateway/allowlist';
 
 export type GatewayFetchInit = {
@@ -20,6 +19,10 @@ export async function gatewayFetch(
   if (!isAllowed(method, pathOnly)) {
     return new Response(null, { status: 404 });
   }
+
+  // Lazy-load env so its zod parse runs at request time, not at build's
+  // "Collecting page data" step (which evaluates the route module).
+  const { env } = await import('@/lib/env');
 
   const headers = new Headers(init?.headers);
   headers.set('X-API-Key', env.ANDAMIO_API_KEY);

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -1,0 +1,52 @@
+import 'server-only';
+
+import { cookies } from 'next/headers';
+
+const SESSION_COOKIE_NAME = 'andamio-session';
+
+// Tracks the Andamio JWT lifetime (~24h). Tighten when the auth flow pins
+// a precise expiry from the validate response.
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24;
+
+export type SessionPayload = {
+  jwt: string;
+  stakeAddress: string;
+};
+
+export async function getSession(): Promise<SessionPayload | null> {
+  const store = await cookies();
+  const cookie = store.get(SESSION_COOKIE_NAME);
+  if (!cookie) return null;
+
+  try {
+    const parsed = JSON.parse(cookie.value) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof (parsed as { jwt?: unknown }).jwt === 'string' &&
+      typeof (parsed as { stakeAddress?: unknown }).stakeAddress === 'string'
+    ) {
+      const { jwt, stakeAddress } = parsed as SessionPayload;
+      return { jwt, stakeAddress };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setSession(payload: SessionPayload): Promise<void> {
+  const store = await cookies();
+  store.set(SESSION_COOKIE_NAME, JSON.stringify(payload), {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+}
+
+export async function clearSession(): Promise<void> {
+  const store = await cookies();
+  store.delete(SESSION_COOKIE_NAME);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
Closes #61

## Summary
The Andamio gateway proxy and session helpers are missing from main. Pages and components that need to talk to Andamio (auth, profile, commitments, courses) have no server-side path, and there is no safe way to attach the ANDAMIO_API_KEY without leaking it to the client. This change lands the three foundations — an httpOnly session cookie helper, a gatewayFetch helper that validates against the existing allowlist and injects X-API-Key (and optionally a forwarded JWT), and the catch-all /api/gateway/[...path] route handler that consumes both — so all subsequent feature work has a server-only path to Andamio with no client-side secret exposure.

## Changes
- `app/api/gateway/[...path]/route.ts`
- `lib/gateway/server.test.ts`
- `lib/gateway/server.ts`
- `lib/session.ts`
- `tsconfig.json`

## QA Results
- Security: PASS
- Correctness: PASS
- Architecture: PASS

## Test Plan
Manual verification