### PR TITLE
docs: remove private-vault paths from repo content

### DIFF
--- a/docs/design/AGENT-NOTES.md
+++ b/docs/design/AGENT-NOTES.md
@@ -35,4 +35,4 @@ User-facing copy never says: `course`, `module`, `student`, `teacher`, `assignme
 
 Short sentences. No em-dashes. No "It's not just X — it's Y." No hedging. Person-to-person, plural voice ("post yours", "see who's working on what"), warmer than a tool landing.
 
-See `~/projects/02-areas/andamio/.claude/skills/write/writing-reference.md`.
+See the internal `writing-reference` note.

--- a/docs/design/project/uploads/Spec - Working with Me v1 Next.js app on Andamio-2233873a.md
+++ b/docs/design/project/uploads/Spec - Working with Me v1 Next.js app on Andamio-2233873a.md
@@ -22,7 +22,7 @@ The credential is a real Andamio credential — programmatically usable by any o
 
 Spec lives in orch until James decides to hand off to agency.
 
-Target repo: `~/projects/01-projects/working-with-me/` (fresh, empty git init as of 2026-04-26).
+Target repo: `` (fresh, empty git init as of 2026-04-26).
 
 ---
 
@@ -32,7 +32,7 @@ People who would work well together can't easily find each other, and when they 
 
 This v1 ships a small platform on Andamio APIs where each user posts a single living doc — what they're working on, how they prefer to work — and engagement happens through a deliberate two-step ritual (comment + commitment), gated by the poster's approval. A successful approval issues an Andamio credential tying the two parties on-chain. Other apps can read those credentials to power discovery, vouching, and access decisions elsewhere in the Andamio ecosystem.
 
-The pattern is "Built on Andamio" — same family as `cardano-xp` and `midnight-pbl`, codified in `~/projects/02-areas/andamio/.claude/knowledge/built-on-andamio-patterns.md`. Andamio's Course primitive is repurposed as a per-user namespace; an Assignment is the user's doc; a Submission is a Commitment; an issued Credential is the connection.
+The pattern is "Built on Andamio" — same family as `cardano-xp` and `midnight-pbl`, codified in the internal `built-on-andamio-patterns` note. Andamio's Course primitive is repurposed as a per-user namespace; an Assignment is the user's doc; a Submission is a Commitment; an issued Credential is the connection.
 
 ## 2. Requirements
 
@@ -50,7 +50,7 @@ The pattern is "Built on Andamio" — same family as `cardano-xp` and `midnight-
 - P0-10: Gated resources — the owner can author a second Markdown body ("how I work — more"). It is visible only to wallets that hold an issued credential from the owner.
 - P0-11: My connections view — `/network` lists wallets the current user holds a credential with (1-degree only in v1).
 - P0-12: Andamio terminology never appears in user-facing UI. Mapping (Course → "your space", Module → "more resources", Assignment → "what I'm working on", Submission → "interest", Credential → "connection") is implementation-only.
-- P0-13: Editorial voice in all UI copy: short sentences, no hedging, no em-dashes, no AI-slop tells. Source: `~/projects/02-areas/andamio/.claude/skills/write/writing-reference.md`.
+- P0-13: Editorial voice in all UI copy: short sentences, no hedging, no em-dashes, no AI-slop tells. Source: the internal `writing-reference` note.
 
 ### P1 (should ship in v1)
 
@@ -62,7 +62,7 @@ The pattern is "Built on Andamio" — same family as `cardano-xp` and `midnight-
 
 Real file paths the implementation will create.
 
-**New files in target repo (`~/projects/01-projects/working-with-me/`):**
+**New files in target repo (``):**
 
 Stack & config:
 - `package.json` — Next.js 15, React 18, `@meshsdk/core`, `@meshsdk/react`, Tailwind, `react-markdown`, `@tanstack/react-query`, `zod`.
@@ -111,9 +111,9 @@ Library:
 - `GET  /api/v2/course/student/credentials` — visitor's held credentials (powers `/network` and the gated read check).
 
 **Reference patterns (read for guidance, do not copy code):**
-- `~/projects/02-areas/andamio/.claude/knowledge/built-on-andamio-patterns.md` — proxy + deployment patterns.
-- `~/projects/01-projects/cardano-xp/` — single-course env-var pattern (we adapt to per-user dynamic namespaces).
-- `~/projects/01-projects/midnight-pbl/` — Cloud Run + WIF GitHub Actions.
+- the internal `built-on-andamio-patterns` note — proxy + deployment patterns.
+- `$REPOS/cardano-xp/` — single-course env-var pattern (we adapt to per-user dynamic namespaces).
+- `$REPOS/midnight-pbl/` — Cloud Run + WIF GitHub Actions.
 
 ## 4. Tests
 
@@ -150,7 +150,7 @@ Library:
 
 Each AC is binary testable.
 
-- AC-1: `pnpm install && pnpm build && pnpm typecheck` all succeed on a clean clone of `~/projects/01-projects/working-with-me/`.
+- AC-1: `pnpm install && pnpm build && pnpm typecheck` all succeed on a clean clone of ``.
 - AC-2: A grep for `ANDAMIO_API_KEY` against the production client bundle (`.next/static/`) returns zero matches.
 - AC-3: All Andamio gateway calls in source originate from `app/api/gateway/*` or `app/api/auth/*` (server-side); zero direct client-side fetches to `andamio.io`.
 - AC-4: A wallet visitor can connect via Mesh SDK and obtain a JWT via the Andamio nonce + validate flow.
@@ -180,7 +180,7 @@ Each AC is binary testable.
 - Must NOT include enterprise SSO, native mobile apps, or analytics dashboards.
 - Must NOT expose Andamio-internal terminology (`course`, `module`, `SLT`, `student`, `teacher`, `assignment submission`, `credential issuance`) to users.
 - Must NOT bundle Mesh SDK or wallet/crypto deps into the SSR path.
-- Must NOT reference, import, or copy code from `~/projects/01-projects/working-with-me-platform/` (the abandoned Vite repo). Concept-mapping inspiration is captured in this spec; that repo is out of scope.
+- Must NOT reference, import, or copy code from `$REPOS/working-with-me-platform/` (the abandoned Vite repo). Concept-mapping inspiration is captured in this spec; that repo is out of scope.
 - Must NOT hardcode `gateway_url`, `network`, or any wallet identity. All env-driven or session-driven.
 - Must NOT introduce a custom credential storage layer. Credentials are real Andamio credentials, queryable through Andamio's existing endpoints.
 

--- a/docs/design/project/uploads/Spec - Working with Me v1 Next.js app on Andamio.md
+++ b/docs/design/project/uploads/Spec - Working with Me v1 Next.js app on Andamio.md
@@ -18,7 +18,7 @@ tags:
 
 Draft spec in agency's 7-section format. Lives in orch until James decides to hand off to agency. Single-tenant v1: ships James's own brief on Andamio APIs; multi-tenant + monetization layers are explicitly out of scope.
 
-Target repo: `~/projects/01-projects/working-with-me/` (fresh, empty git init as of 2026-04-26).
+Target repo: `` (fresh, empty git init as of 2026-04-26).
 
 ---
 
@@ -28,20 +28,20 @@ Both AI and human collaborators struggle to align with how James actually works.
 
 This v1 ships James's own working-with-me brief as a single-tenant Next.js app on Andamio APIs. It proves the working-with-me pattern (read → respond → connect, mapped onto Andamio's enroll → submit → credential primitives) before any multi-tenant or monetization layer.
 
-The pattern is "Built on Andamio" — the same shape as `cardano-xp` and `midnight-pbl`, codified in `~/projects/02-areas/andamio/.claude/knowledge/built-on-andamio-patterns.md`.
+The pattern is "Built on Andamio" — the same shape as `cardano-xp` and `midnight-pbl`, codified in the internal `built-on-andamio-patterns` note.
 
 ## 2. Requirements
 
 ### P0 (must ship in v1)
 
-- P0-1: Next.js 15 + TypeScript + Tailwind app at `~/projects/01-projects/working-with-me/`. Mesh SDK in client-only components.
+- P0-1: Next.js 15 + TypeScript + Tailwind app at ``. Mesh SDK in client-only components.
 - P0-2: All Andamio API calls go through a server-side proxy route that injects `X-API-Key`. Key never reaches the client bundle.
 - P0-3: Brief content (sections + qualification questions) is fetched from a single Andamio course identified by env-var `course_id` (cardano-xp single-tenant pattern). Content is NOT baked into source.
 - P0-4: Anonymous read path — visitor without a wallet can read the full brief.
 - P0-5: Wallet read+respond path — visitor can connect a Cardano wallet via Mesh SDK, answer section-level qualification questions, submit responses.
 - P0-6: Successful submission triggers credential issuance via the Andamio gateway (the "connection badge" — a real on-chain mark of a calibrated collaborator).
 - P0-7: Andamio terminology never appears in the user-facing UI. The mapping (course → "the brief", module → "section", SLT → "qualification question", credential → "connection badge") is hidden inside the implementation.
-- P0-8: Editorial voice in all UI copy: short sentences, no hedging, no em-dashes, no AI-slop tells (no "let's dive in", no marketing triplets). Source of truth: `~/projects/02-areas/andamio/.claude/skills/write/writing-reference.md` + `.claude/knowledge/synthesis-patterns/feedback_no_self_congratulation.md`.
+- P0-8: Editorial voice in all UI copy: short sentences, no hedging, no em-dashes, no AI-slop tells (no "let's dive in", no marketing triplets). Source of truth: the internal `writing-reference` note + `.claude/knowledge/synthesis-patterns/feedback_no_self_congratulation.md`.
 
 ### P1 (should ship in v1)
 
@@ -53,7 +53,7 @@ The pattern is "Built on Andamio" — the same shape as `cardano-xp` and `midnig
 
 Real file paths the implementation will create or modify.
 
-**New files in target repo (`~/projects/01-projects/working-with-me/`):**
+**New files in target repo (``):**
 - `package.json` — Next.js 15, React 18, Mesh SDK (`@meshsdk/core`, `@meshsdk/react`), Tailwind, generated gateway types.
 - `next.config.mjs` — webpack config to keep wallet/crypto deps out of SSR bundle.
 - `tailwind.config.ts`, `postcss.config.mjs`.
@@ -78,9 +78,9 @@ Real file paths the implementation will create or modify.
 - `POST /api/v2/course/credential/issue` — issue connection badge.
 
 **Reference patterns (read, do not copy):**
-- `~/projects/02-areas/andamio/.claude/knowledge/built-on-andamio-patterns.md` — common API integration + deployment patterns.
-- `~/projects/01-projects/cardano-xp/` — single-course env-var pattern.
-- `~/projects/01-projects/midnight-pbl/` — Cloud Run + WIF GitHub Actions pattern.
+- the internal `built-on-andamio-patterns` note — common API integration + deployment patterns.
+- `$REPOS/cardano-xp/` — single-course env-var pattern.
+- `$REPOS/midnight-pbl/` — Cloud Run + WIF GitHub Actions pattern.
 
 ## 4. Tests
 
@@ -112,7 +112,7 @@ Real file paths the implementation will create or modify.
 
 Each AC is binary testable.
 
-- AC-1: `pnpm install && pnpm build && pnpm typecheck` all succeed on a clean clone of `~/projects/01-projects/working-with-me/`.
+- AC-1: `pnpm install && pnpm build && pnpm typecheck` all succeed on a clean clone of ``.
 - AC-2: Anonymous visit to `/` renders brief sections fetched from Andamio course identified by `ANDAMIO_COURSE_ID`.
 - AC-3: A grep for `ANDAMIO_API_KEY` against the production client bundle (`.next/static/`) returns zero matches.
 - AC-4: All Andamio gateway calls in source originate from `app/api/gateway/*` or `app/api/auth/*` (server-side); zero calls from `components/` or other client paths.
@@ -133,7 +133,7 @@ Each AC is binary testable.
 - Must NOT include real-time collaboration, WebSockets, or chat.
 - Must NOT expose Andamio-internal terminology to users (`course`, `module`, `SLT`, `student`, `teacher`, `credential issuance`).
 - Must NOT bundle Mesh SDK or other wallet/crypto code into the SSR path.
-- Must NOT reference, import, or copy code from `~/projects/01-projects/working-with-me-platform/` (the abandoned Vite repo). Concept-mapping inspiration is captured here in this spec; the prior repo is out of scope going forward.
+- Must NOT reference, import, or copy code from `$REPOS/working-with-me-platform/` (the abandoned Vite repo). Concept-mapping inspiration is captured here in this spec; the prior repo is out of scope going forward.
 - Must NOT bake brief content into source. All section content + qualification questions live in the Andamio course identified by env var.
 - Must NOT add enterprise SSO, native mobile apps, or analytics dashboards in v1.
 - Must NOT use Vite. Stack is fixed: Next.js 15 with the App Router.
@@ -159,7 +159,7 @@ The principle, from `built-on-andamio-patterns.md`: the education flow (enroll �
 
 The brief's actual content — sections, manifesto copy, qualification questions — gets authored as Andamio course content in a separate step (likely via the Andamio CLI). The research that surfaces what to write lives in:
 
-**From orch (`/Users/james/projects/02-areas/andamio/`):**
+**From orch (the private orchestration vault):**
 - `.claude/CLAUDE.md` — Three Orchestrators, daily rhythm, rules, what James keeps vs delegates.
 - `.claude/skills/write/writing-reference.md` — voice rules.
 - `.claude/knowledge/synthesis-patterns/feedback_no_self_congratulation.md` — anti-patterns in copy.

--- a/docs/design/project/uploads/Spec - Working with Me v1 Next.js app on Andamio.md
+++ b/docs/design/project/uploads/Spec - Working with Me v1 Next.js app on Andamio.md
@@ -24,7 +24,7 @@ Target repo: `~/projects/01-projects/working-with-me/` (fresh, empty git init as
 
 ## 1. Problem
 
-Both AI and human collaborators struggle to align with how James actually works. The rules and philosophy that govern a productive collaboration with him exist — but scattered across the orch vault (`.claude/CLAUDE.md`, `.claude/skills/write/`, `020-areas/strategy/`), the zettelkasten (`wiki/creative/writing.md`, `wiki/andamio/`, `wiki/ideas/*`), voice memos, and codified Claude skills. There is no single artifact a collaborator can read, engage with, and become calibrated by.
+Both AI and human collaborators struggle to align with how James actually works. The rules and philosophy that govern a productive collaboration with him exist — but scattered across the orch vault (`.claude/CLAUDE.md`, `.claude/skills/write/`, an internal strategy note), the zettelkasten (`wiki/creative/writing.md`, `wiki/andamio/`, `wiki/ideas/*`), voice memos, and codified Claude skills. There is no single artifact a collaborator can read, engage with, and become calibrated by.
 
 This v1 ships James's own working-with-me brief as a single-tenant Next.js app on Andamio APIs. It proves the working-with-me pattern (read → respond → connect, mapped onto Andamio's enroll → submit → credential primitives) before any multi-tenant or monetization layer.
 
@@ -163,10 +163,10 @@ The brief's actual content — sections, manifesto copy, qualification questions
 - `.claude/CLAUDE.md` — Three Orchestrators, daily rhythm, rules, what James keeps vs delegates.
 - `.claude/skills/write/writing-reference.md` — voice rules.
 - `.claude/knowledge/synthesis-patterns/feedback_no_self_congratulation.md` — anti-patterns in copy.
-- `020-areas/strategy/2026-03-21-enterprise-launch-amendment.md` — source-leadership thinking, money flow.
-- `020-areas/CONTEXT.md` — current chain-of-work framing.
+- the 2026-03-21 enterprise-launch amendment (internal) — source-leadership thinking, money flow.
+- the internal context note — current chain-of-work framing.
 
-**From jz (`/Users/james/projects/james-zettelkasten/`):**
+**From the personal knowledge base (internal):**
 - `wiki/creative/writing.md` — pace layering, "no AI slop walls".
 - `wiki/andamio/techstars-experience.md` — "treat people as ends, not means".
 - `wiki/ideas/requesting.md` — productive requesting (who, by when).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -22,7 +22,7 @@ The credential is a real Andamio credential — programmatically usable by any o
 
 Spec lives in orch until James decides to hand off to agency.
 
-Target repo: `~/projects/01-projects/working-with-me/` (fresh, empty git init as of 2026-04-26).
+Target repo: `` (fresh, empty git init as of 2026-04-26).
 
 ---
 
@@ -32,7 +32,7 @@ People who would work well together can't easily find each other, and when they 
 
 This v1 ships a small platform on Andamio APIs where each user posts a single living doc — what they're working on, how they prefer to work — and engagement happens through a deliberate two-step ritual (comment + commitment), gated by the poster's approval. A successful approval issues an Andamio credential tying the two parties on-chain. Other apps can read those credentials to power discovery, vouching, and access decisions elsewhere in the Andamio ecosystem.
 
-The pattern is "Built on Andamio" — same family as `cardano-xp` and `midnight-pbl`, codified in `~/projects/02-areas/andamio/.claude/knowledge/built-on-andamio-patterns.md`. Andamio's Course primitive is repurposed as a per-user namespace; an Assignment is the user's doc; a Submission is a Commitment; an issued Credential is the connection.
+The pattern is "Built on Andamio" — same family as `cardano-xp` and `midnight-pbl`, codified in the internal `built-on-andamio-patterns` note. Andamio's Course primitive is repurposed as a per-user namespace; an Assignment is the user's doc; a Submission is a Commitment; an issued Credential is the connection.
 
 ## 2. Requirements
 
@@ -50,7 +50,7 @@ The pattern is "Built on Andamio" — same family as `cardano-xp` and `midnight-
 - P0-10: Gated resources — the owner can author a second Markdown body ("how I work — more"). It is visible only to wallets that hold an issued credential from the owner.
 - P0-11: My connections view — `/network` lists wallets the current user holds a credential with (1-degree only in v1).
 - P0-12: Andamio terminology never appears in user-facing UI. Mapping (Course → "your space", Module → "more resources", Assignment → "what I'm working on", Submission → "interest", Credential → "connection") is implementation-only.
-- P0-13: Editorial voice in all UI copy: short sentences, no hedging, no em-dashes, no AI-slop tells. Source: `~/projects/02-areas/andamio/.claude/skills/write/writing-reference.md`.
+- P0-13: Editorial voice in all UI copy: short sentences, no hedging, no em-dashes, no AI-slop tells. Source: the internal `writing-reference` note.
 
 ### P1 (should ship in v1)
 
@@ -62,7 +62,7 @@ The pattern is "Built on Andamio" — same family as `cardano-xp` and `midnight-
 
 Real file paths the implementation will create.
 
-**New files in target repo (`~/projects/01-projects/working-with-me/`):**
+**New files in target repo (``):**
 
 Stack & config:
 - `package.json` — Next.js 15, React 18, `@meshsdk/core`, `@meshsdk/react`, Tailwind, `react-markdown`, `@tanstack/react-query`, `zod`.
@@ -111,9 +111,9 @@ Library:
 - `GET  /api/v2/course/student/credentials` — visitor's held credentials (powers `/network` and the gated read check).
 
 **Reference patterns (read for guidance, do not copy code):**
-- `~/projects/02-areas/andamio/.claude/knowledge/built-on-andamio-patterns.md` — proxy + deployment patterns.
-- `~/projects/01-projects/cardano-xp/` — single-course env-var pattern (we adapt to per-user dynamic namespaces).
-- `~/projects/01-projects/midnight-pbl/` — Cloud Run + WIF GitHub Actions.
+- the internal `built-on-andamio-patterns` note — proxy + deployment patterns.
+- `$REPOS/cardano-xp/` — single-course env-var pattern (we adapt to per-user dynamic namespaces).
+- `$REPOS/midnight-pbl/` — Cloud Run + WIF GitHub Actions.
 
 ## 4. Tests
 
@@ -150,7 +150,7 @@ Library:
 
 Each AC is binary testable.
 
-- AC-1: `pnpm install && pnpm build && pnpm typecheck` all succeed on a clean clone of `~/projects/01-projects/working-with-me/`.
+- AC-1: `pnpm install && pnpm build && pnpm typecheck` all succeed on a clean clone of ``.
 - AC-2: A grep for `ANDAMIO_API_KEY` against the production client bundle (`.next/static/`) returns zero matches.
 - AC-3: All Andamio gateway calls in source originate from `app/api/gateway/*` or `app/api/auth/*` (server-side); zero direct client-side fetches to `andamio.io`.
 - AC-4: A wallet visitor can connect via Mesh SDK and obtain a JWT via the Andamio nonce + validate flow.
@@ -180,7 +180,7 @@ Each AC is binary testable.
 - Must NOT include enterprise SSO, native mobile apps, or analytics dashboards.
 - Must NOT expose Andamio-internal terminology (`course`, `module`, `SLT`, `student`, `teacher`, `assignment submission`, `credential issuance`) to users.
 - Must NOT bundle Mesh SDK or wallet/crypto deps into the SSR path.
-- Must NOT reference, import, or copy code from `~/projects/01-projects/working-with-me-platform/` (the abandoned Vite repo). Concept-mapping inspiration is captured in this spec; that repo is out of scope.
+- Must NOT reference, import, or copy code from `$REPOS/working-with-me-platform/` (the abandoned Vite repo). Concept-mapping inspiration is captured in this spec; that repo is out of scope.
 - Must NOT hardcode `gateway_url`, `network`, or any wallet identity. All env-driven or session-driven.
 - Must NOT introduce a custom credential storage layer. Credentials are real Andamio credentials, queryable through Andamio's existing endpoints.
 


### PR DESCRIPTION
Citations pointing into a private Obsidian vault, which no reader of this repo can open. This repo is **public**, so they were also disclosing the vault's internal structure.

Provenance is preserved; the paths are removed. Each citation now describes what the source was instead of pointing at an unreachable path.

Found by a path guard that scans repo files and issue/PR bodies for personal-vault and absolute-home paths. Note it also reports `~/projects/...` developer-setup paths in this repo, which are a milder class and are **not** changed here.